### PR TITLE
Add TeamCherry.*.dll files to GameFiles item

### DIFF
--- a/Silksong.GameLibs.csproj
+++ b/Silksong.GameLibs.csproj
@@ -58,6 +58,7 @@
   <ItemGroup>
     <GameFiles Include="ref/$(TargetSilksongVersion)/Assembly-CSharp.dll" Publicize="true" Strip="true"/>
     <GameFiles Include="ref/$(TargetSilksongVersion)/PlayMaker.dll" Publicize="true" Strip="true"/>
+    <GameFiles Include="ref/$(TargetSilksongVersion)/TeamCherry.*.dll" Publicize="true" Strip="true"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added the files that match `TeamCherry.*.dll` to the `GameFiles` item in the `.csproj` to include them in the strip and publicize step.
These also contain methods that one might want to access without reflection and are not system files.