### PR TITLE
Add build script to build all versions, require version set outside project

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,34 @@ to you.
 
 To build this package, you should have ready:
 
-- The version of the game you want to mod
+- The version(s) of the game you want to mod
 - The dotnet CLI to build (Visual Studio's build environment will not work because it does not support netstandard2.1)
 
-Then do the following:
+### Building for all supported versions
+
+A build script, `build-all.sh`, is provided to build the package for all supported Silksong versions. This script will automatically build for each version listed in the script. You can optionally specify the build configuration (e.g. Release or Debug) using the `-c` or `--configuration` flag (default is Debug):
+
+```sh
+./build-all.sh -c Release
+```
+
+This will invoke `dotnet build` for each version, setting the required `TargetSilksongVersion` property and the specified configuration.
+
+### Building for a single version manually
+
+If you want to build for a specific Silksong version, you must set the `TargetSilksongVersion` property manually:
+
+```sh
+dotnet build -c Release -p:TargetSilksongVersion=1.0.28324
+```
+
+Replace `1.0.28324` with the desired version. The build will fail if `TargetSilksongVersion` is not set.
+
+### Preparing game files
 
 1. Note down the game version and related Steam depot IDs. Add them in a comment in the csproj so that future builders can
    retrieve that version to build against it again in the future.
-2. Update the TargetSilksongVersion property in the csproj.
-3. Copy the contents of the Managed folder to `ref/(game version)`, for example, `ref/1.0.28324`
-4. Run `dotnet build`. This will strip and publicize the configured files and bundle everything to a nuget package.
+2. Copy the contents of the Managed folder to `ref/(game version)`, for example, `ref/1.0.28324`
 
 Adding/removing assemblies in the build and/or publicization can be done by adjusting the SystemFiles and GameFiles item groups
 in the csproj.

--- a/Silksong.GameLibs.csproj
+++ b/Silksong.GameLibs.csproj
@@ -1,21 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <!--steam depots - windows: 1030301 - mac: 1030302 - linux: 1030303 -->
-
-    <!-- version 1.0.28324 manifests - windows: 3229726349000518284 - mac: 1365730835793684614 - linux: 8384590172287463475 -->
-    <!--<TargetSilksongVersion>1.0.28324</TargetSilksongVersion>-->
-
-    <!-- version 1.0.28497 manifests - windows: 539129767115354441 - mac: 8670159430480702509 - linux: 6701825740120558137 -->
-    <!--<TargetSilksongVersion>1.0.28497</TargetSilksongVersion>-->
-
-    <!-- version 1.0.28561 manifests - windows: 8642535143474926050 - mac: 9022715293716759452 - linux: 6373658714389144408  -->
-    <TargetSilksongVersion>1.0.28561</TargetSilksongVersion>
-  </PropertyGroup>
+  <!-- Fail the build if TargetSilksongVersion is not set, as early as possible -->
+  <Target Name="EnsureTargetSilksongVersionSet" BeforeTargets="ResolveReferences">
+    <Error Condition=" '$(TargetSilksongVersion)' == '' " Text="TargetSilksongVersion property must be set (e.g. via -p:TargetSilksongVersion=1.0.28324)" />
+  </Target>
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <PackageVersion>1.0.2-silksong$(TargetSilksongVersion)</PackageVersion>
+    <PackageVersion>1.1.0-silksong$(TargetSilksongVersion)</PackageVersion>
     <Authors>BadMagic</Authors>
     <Description>The game libraries used for modding Hollow Knight: Silksong</Description>
     <PackageTags>silksong modding bepinex5</PackageTags>
@@ -89,7 +81,6 @@
   <!-- 
   TODO - add a hookgen target later, currently does not work but we don't have a way to distribute the generated hooks to players yet anyway
   Can refer to https://github.com/BadMagic100/Grime.GameLibs/blob/d1189a5858d77fb5000f7db00be73113ac62798c/Grime.GameLibs.csproj#L59 as a starting point
-  
   -->
 
 

--- a/build-all.sh
+++ b/build-all.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Steam depots:
+#   windows: 1030301
+#   mac:     1030302
+#   linux:   1030303
+#
+# version 1.0.28324 manifests:
+#   windows: 3229726349000518284
+#   mac:     1365730835793684614
+#   linux:   8384590172287463475
+#
+# version 1.0.28497 manifests:
+#   windows: 539129767115354441
+#   mac:     8670159430480702509
+#   linux:   6701825740120558137
+#
+# version 1.0.28561 manifests:
+#   windows: 8642535143474926050
+#   mac:     9022715293716759452
+#   linux:   6373658714389144408
+
+set -e
+
+# Default configuration
+CONFIGURATION="Debug"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -c|--configuration)
+      CONFIGURATION="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+versions=(
+  "1.0.28324"
+  "1.0.28497"
+  "1.0.28561"
+)
+
+for version in "${versions[@]}"; do
+  echo "Building for Silksong version $version with configuration $CONFIGURATION..."
+  dotnet build -c "$CONFIGURATION" -p:TargetSilksongVersion=$version
+  if [ $? -ne 0 ]; then
+    echo "Build failed for version $version"
+    exit 1
+  fi
+done
+
+echo "All versions built successfully!"


### PR DESCRIPTION
This should make it easier to do bulk builds of old game versions when gamelibs changes. I tested this by doing the build backfill against the changes in #1 and it was indeed easier than changing all the csproj comments