### PR TITLE
Add DownloadDepots target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,82 +15,76 @@ additional features such as shell completion and secret management. If you don't
 of the bootstrap scripts (`build.cmd` for windows, `build.ps1` for powershell, or `build.sh` for mac/linux) in place of `nuke`
 in all of the example commands below.
 
-### Preparing game files for an installed patch
+### Common Parameters
 
-1. Note down the game version and related Steam manifest IDs. Add them to `build/SilksongVersionInfo.cs` so they can be used in
-   builds.
-   - The easiest way to get manifest versions is to go to [SteamDB](https://steamdb.info/app/1030300/patchnotes/), find the patch
-     corresponding to the update date, and then grab the new manifest ids from the bottom of each depot's section of the patch page.
-2. Copy the contents of the Managed folder to `ref/(game version)`, for example, `ref/1.0.28324`
+The following parameters are supported in all build targets except for Clean:
+
+- `--target-silksong-versions`: The versions of Silksong to run the command for. Multiple versions can be specified separated
+                                by spaces, e.g. `--target-silksong-versions 1.0.29980 1.0.30000`. If not specified, the command
+                                will run for all known versions.
+- `--dry-run`: Treats the build as a dryrun build. Actions will be logged, but not performed. This is helpful for testing and
+               verification purposes
+
+### Secret Parameters
+
+Certain parameters contain highly sensitive information like NuGet tokens or Steam passwords. Rather than enter/store these
+in plaintext, you can use Nuke's secret management tooling. The recommended way to do this is as follows:
+
+1. Create an empty json file at `.nuke/parameters.local-secrets.json` and copy the `$schema` from `parameters.json`. This
+   file is gitignored so you can use your own secrets
+2. Run `nuke :secrets local-secrets`, choose a password, and use the interface to enter your secrets, then save.
+3. In future runs requiring secrets, provide the flag `--profile local-secrets` to load your encrypted secrets from the file.
+   You will be prompted to re-enter the chosen password
+
+Refer to [Nuke's documentation](https://nuke.build/docs/global-tool/secrets/) for additional detail.
+
+There are also less-secure ways to enter secrets, should you choose to do so:
+
+- With command line flags as usual (preferred for future CI use cases)
+- In a `parameters.<profile>.json` entry using plaintext instead Nuke's encryption mechanism
+- In an environment variable, such as `NUGET_API_KEY` or `NUKE_NUGET_API_KEY`
+
+### Preparing game files
+
+If adding support for a new patch, the first step is to record the version and manifest IDs for each depot at that version
+in `build/SilksongVersionInfo.cs`. The easiest way to retrieve these is from [SteamDB](https://steamdb.info/app/1030300/patchnotes/);
+find the patch corresponding to the release date and copy down the new manifest IDs from the bottom of each depot's secion
+of the patch page.
+
+Game files can be downloaded using `nuke download-depots`. This will prompt you to log into Steam. You must own the game on
+Steam to use this tooling. By default, a Steam Guard QR code will be generated to log in without typing your username and password.
+The secret parameters `--steam-user` and `--steam-password` can be used to log in by credentials, which is especially useful if
+you do not have 2FA/Steam Guard. See the section about secret management above for best practices.
+
+If you have the game on another platform like GOG you can also manually copy the content of the `Managed` folder to the 
+`ref/<game version>`, preferably with the Windows copy of the game for consistency. However, it is generally harder or impossible
+to access very old versions of the game from non-Steam platforms.
 
 Adding/removing assemblies in the build and/or publicization can be done by adjusting the SystemFiles and GameFiles item groups
 in the csproj.
 
-### Retrieving files for old patches using DepotDownloader
+### Building packages
 
-In the event of missing a patch or tranferring ownership, retrieving references for old files will be necessary. In such
-cases, [DepotDownloader](https://github.com/SteamRE/DepotDownloader) can be used to retrieve them from Steam.
+Packages can be built using `nuke package`. Packaging requires game files to be available in the `ref` folder. Steam users
+can accomplish this with the `download-depots` target as detailed above.
 
-1. Collect the app, depot, and manifest ID
-    1. App ID is `1030300`
-    2. Depot ID is `1030301` for Windows, `1030302` for Mac, and `1030303` for Linux. For consistency, using the Windows
-       depot is probably desirable even if you are not on Windows.
-    3. Manifest ID is documented in `build-all.sh` for each patch.
-2. Create a refs folder for the target version: `mkdir refs/<target version>`
-3. Run depot downloader 
-   ```sh
-   depotdownloader -app 1030300 \
-       -depot 1030301 \
-       -manifest <manifest of target version> \
-       -dir ref/<target version> \
-       -filelist depotdownloader-file-filter.txt \
-       -qr
-   ```
-4. Move the files up to the root level of the refs directory and delete the `Hollow Knight Silksong_Data` and `.DepotDownloader`
-   directories.
+### Publishing packages
+
+Packages can be published using `nuke publish`. A NuGet API key (`--nuget-api-key`) with the appropriate publishing scope 
+is also required; see the section about secret management above for best practices.
+
+The publishing target has several guard rails to prevent incorrect publishes. Before publishing it will:
+
+1. Clean and rebuild old build artifacts
+2. Check that you are on the main branch and that it is up to date with origin/main
+3. Check that you have no uncommitted changes
 
 ### Cleaning up
 
 Build artifacts can be cleaned up with `nuke clean`.
 
-### Building packages
+### Combining targets
 
-Packages can be built using `nuke package`. Optionally, you can specify a specific version or list of versions to limit the
-scope of build, such as:
-```sh
-nuke package --target-silksong-versions 1.0.29980 1.0.30000
-```
-
-The `--dry-run` flag can be specified to indicate what actions will be taken without performing them.
-
-### Publishing packages
-
-Packages can be published using `nuke publish`. Similar to the build, you can specify a specific version or list of versions
-to publish, and use the `--dry-run` flag to run through the prerequisite checks and action plan without executing it. A NuGet
-API key with the appropriate publishing scope is also required; see the next section for additional details
-
-The publishing target has several guard rails to prevent incorrect publishes; it will:
-
-1. Clean and rebuild old build artifacts
-2. Check that you are on the main branch and that it is up to date with origin/main
-3. Check that you have no uncommitted changes
-4. Run `dotnet nuget push --skip-duplicate` for all generated packages using an API key you provide
-
-#### API Key Handling
-
-NuGet API keys should be treated with care to prevent malicious actors from hijacking the update feed. Nuke has
-built-in secret management through the global tool. The recommended steps to manage the API are as follows:
-
-1. Create an empty json file at `build/parameters.local-secrets.json` and copy the `$schema` from `parameters.json`. This
-   file is gitignored so you can use your own secrets
-2. Run `nuke :secrets local-secrets`, choose a password, and use the interface to enter your API key, then save.
-3. In future runs of `nuke publish`, provide the flag `--profile local-secrets` to load your encrypted secrets from the file.
-   You will be prompted to re-enter the chosen password
-
-Refer to [Nuke's documentation](https://nuke.build/docs/global-tool/secrets/) for additional detail.
-
-There are also less-secure ways to enter the API key, should you choose to do so:
-
-- In a `parameters.<profile>.json` entry using plaintext instead Nuke's encryption mechanism
-- With the `--nuget-api-key` flag
-- In an environment variable, `NUGET_API_KEY` or `NUKE_NUGET_API_KEY`
+Nuke supports chaining targets and will ensure that they execute in the correct order. For example, to download depots, build,
+and publish from a fresh state, you might do `nuke clean download-depots publish` and all 3 targets will be executed. You can
+use `nuke --plan` to visualize the order targets will be executed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,9 @@ of the patch page.
 
 Game files can be downloaded using `nuke download-depots`. This will prompt you to log into Steam. You must own the game on
 Steam to use this tooling. By default, a Steam Guard QR code will be generated to log in without typing your username and password.
-The secret parameters `--steam-user` and `--steam-password` can be used to log in by credentials, which is especially useful if
+Using a QR code is the most secure way to log in to Steam if possible, as the credentials are never stored outside program memory
+and therefore cannot be leaked. If QR code login is not available (e.g. because of https://github.com/silksong-modding/Silksong.GameLibs/issues/16)
+the secret parameters `--steam-user` and `--steam-password` can be used to log in by credentials, which is especially useful if
 you do not have 2FA/Steam Guard. See the section about secret management above for best practices.
 
 If you have the game on another platform like GOG you can also manually copy the content of the `Managed` folder to the 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -7,10 +7,14 @@ using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.Git;
 using Serilog;
+using SteamKit2;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
-class Build : NukeBuild
+partial class Build : NukeBuild
 {
     [Solution(GenerateProjects = true)]
     readonly Solution Solution;
@@ -31,18 +35,26 @@ class Build : NukeBuild
     [Secret, Parameter("The NuGet API key to use for publishing")]
     readonly string NuGetApiKey;
 
+    [Secret, Parameter("Steam username for downloading game files in DepotDownload target. If either username or password is absent, QR login will be used.")]
+    readonly string SteamUser;
+    [Secret, Parameter("Steam password for downloading game files in DepotDownload target. If either username or password is absent, QR login will be used.")]
+    readonly string SteamPassword;
+
     readonly AbsolutePath BinDir = RootDirectory / "bin";
     readonly AbsolutePath ObjDir = RootDirectory / "obj";
+    readonly AbsolutePath DepotStagingDir = TemporaryDirectory / "depots";
 
     Target Clean => _ => _
-        .Before(Package, Publish)
+        .Before(DownloadDepots, Package, Publish)
         .Executes(() =>
         {
             BinDir.CreateOrCleanDirectory();
             ObjDir.CreateOrCleanDirectory();
+            DepotStagingDir.CreateOrCleanDirectory();
         });
 
     Target Package => _ => _
+        .Description("Builds NuGet packages for the specified game versions. If no versions are specified, all versions will be build.")
         .Executes(() =>
         {
             IEnumerable<SilksongVersionInfo> targetVersions = GetTargetVersions();
@@ -65,6 +77,7 @@ class Build : NukeBuild
         });
 
     Target Publish => _ => _
+        .Description("Publishes NuGet packages for the specified game versions with guardrails. If no versions are specified, all versions will published.")
         .DependsOn(Clean, Package)
         .Requires(() => NuGetApiKey)
         .Executes(() =>
@@ -102,10 +115,101 @@ class Build : NukeBuild
             );
         });
 
+    Target DownloadDepots => _ => _
+        .Description("Downloads game files for the specified game versions. If no versions are specified, all versions will be downloaded.")
+        .Before(Package)
+        .Executes(async () =>
+        {
+            IEnumerable<SilksongVersionInfo> targetVersions = GetTargetVersions();
+            Log.Information("Downloading game files for target versions {Versions}", string.Join(", ", targetVersions));
+
+            SteamClientWrapper clientWrapper = new();
+
+            await clientWrapper.ConnectAndLoginAsync(SteamUser, SteamPassword);
+
+            uint depotId = SilksongVersionInfo.STEAM_DEPOT_ID_WINDOWS;
+
+            if (DryRun)
+            {
+                Log.Information("All downloads will be skipped in dryrun mode");
+            }
+
+            await Parallel.ForEachAsync(targetVersions, new ParallelOptions { MaxDegreeOfParallelism = 8 }, async (v, ct) =>
+            {
+                AbsolutePath targetDir = RootDirectory / "ref" / v;
+                if (!IsEmptyOrAbsentDirectory(targetDir))
+                {
+                    Log.Warning("{TargetPath} exists and is not empty, skipping download", targetDir);
+                    return;
+                }
+
+                AbsolutePath intermediateDir = DepotStagingDir / v;
+                intermediateDir.CreateOrCleanDirectory();
+
+                DepotManifest manifest = await clientWrapper.GetManifestAsync(depotId, v.WindowsManifestId);
+                IEnumerable<DepotManifest.FileData> validFiles = manifest.Files
+                    .Where(x =>
+                        !x.Flags.HasFlag(EDepotFileFlag.Directory)
+                        && !x.Flags.HasFlag(EDepotFileFlag.Symlink)
+                    );
+                foreach (DepotManifest.FileData file in validFiles)
+                {
+                    ct.ThrowIfCancellationRequested();
+
+                    // normalize to unix-like file names
+                    file.FileName = file.FileName.Replace('\\', '/');
+                    if (ManifestPathMatcher().IsMatch(file.FileName))
+                    {
+                        string relativePath = Path.GetRelativePath("Hollow Knight Silksong_Data/Managed", Path.TrimEndingDirectorySeparator(file.FileName));
+                        AbsolutePath intermediatePath = intermediateDir / relativePath;
+                        Log.Information("{Version}: Downloading {File} to {Path}", v, relativePath, intermediatePath);
+
+                        if (DryRun)
+                        {
+                            continue;
+                        }
+
+                        await clientWrapper.DownloadFileAsync(depotId, file, intermediatePath.ToFileInfo(), ct);
+                    }
+                }
+
+                Log.Information("{Version}: Copying {Intermediate} to {Target}", v, intermediateDir, targetDir);
+                intermediateDir.Copy(targetDir, ExistsPolicy.DirectoryMerge, createDirectories: true);
+            });
+
+            await clientWrapper.LogOutAsync();
+        });
+
     private IEnumerable<SilksongVersionInfo> GetTargetVersions()
     {
         return TargetSilksongVersions != null && TargetSilksongVersions.Length > 0
             ? TargetSilksongVersions
             : SilksongVersionInfo.AllVersions;
     }
+
+    private bool IsEmptyOrAbsentDirectory(AbsolutePath path)
+    {
+        if (path.FileExists())
+        {
+            // file is not a directory!
+            return false;
+        }
+
+        if (!path.DirectoryExists())
+        {
+            // doesn't exist
+            return true;
+        }
+
+        if (path.GetFiles().Any() || path.GetDirectories().Any())
+        {
+            // has stuff in it
+            return false;
+        }
+
+        return true;
+    }
+
+    [GeneratedRegex(@"^Hollow Knight Silksong_Data/Managed/.+$")]
+    private static partial Regex ManifestPathMatcher();
 }

--- a/build/SilksongVersionInfo.cs
+++ b/build/SilksongVersionInfo.cs
@@ -12,10 +12,10 @@ namespace _build;
 [TypeConverter(typeof(Converter))]
 public class SilksongVersionInfo : Enumeration
 {
-    public const string STEAM_APPID = "1030300";
-    public const string STEAM_DEPOT_ID_WINDOWS = "1030301";
-    public const string STEAM_DEPOT_ID_MAC = "1030302";
-    public const string STEAM_DEPOT_ID_LINUX = "1030303";
+    public const uint STEAM_APPID = 1030300;
+    public const uint STEAM_DEPOT_ID_WINDOWS = 1030301;
+    public const uint STEAM_DEPOT_ID_MAC = 1030302;
+    public const uint STEAM_DEPOT_ID_LINUX = 1030303;
 
     public static IEnumerable<SilksongVersionInfo> AllVersions => [
         .. typeof(SilksongVersionInfo).GetFields(BindingFlags.Public | BindingFlags.Static)
@@ -24,40 +24,40 @@ public class SilksongVersionInfo : Enumeration
     ];
     public static IEnumerable<string> AllVersionStrings => AllVersions.Select(x => x.ToString());
 
-    public required string WindowsManifestId { get; init; }
-    public required string MacManifestId { get; init; }
-    public required string LinuxManifestId { get; init; }
+    public required ulong WindowsManifestId { get; init; }
+    public required ulong MacManifestId { get; init; }
+    public required ulong LinuxManifestId { get; init; }
 
     public static readonly SilksongVersionInfo _1_0_28324 = new()
     {
         Value = "1.0.28324",
-        WindowsManifestId = "3229726349000518284",
-        MacManifestId = "1365730835793684614",
-        LinuxManifestId = "8384590172287463475"
+        WindowsManifestId = 3229726349000518284,
+        MacManifestId = 1365730835793684614,
+        LinuxManifestId = 8384590172287463475
     };
 
     public static readonly SilksongVersionInfo _1_0_28497 = new()
     {
         Value = "1.0.28497",
-        WindowsManifestId = "539129767115354441",
-        MacManifestId = "8670159430480702509",
-        LinuxManifestId = "6701825740120558137"
+        WindowsManifestId = 539129767115354441,
+        MacManifestId = 8670159430480702509,
+        LinuxManifestId = 6701825740120558137
     };
 
     public static readonly SilksongVersionInfo _1_0_28561 = new()
     {
         Value = "1.0.28561",
-        WindowsManifestId = "8642535143474926050",
-        MacManifestId = "9022715293716759452",
-        LinuxManifestId = "6373658714389144408"
+        WindowsManifestId = 8642535143474926050,
+        MacManifestId = 9022715293716759452,
+        LinuxManifestId = 6373658714389144408
     };
 
     public static readonly SilksongVersionInfo _1_0_28650 = new()
     {
         Value = "1.0.28650",
-        WindowsManifestId = "3900764848237536293",
-        MacManifestId = "7832939953657548180",
-        LinuxManifestId = "7495630131038458486"
+        WindowsManifestId = 3900764848237536293,
+        MacManifestId = 7832939953657548180,
+        LinuxManifestId = 7495630131038458486
     };
 
     // note: win and mac have the patch for CVE-2025-59489 on 2025-10-03.
@@ -66,65 +66,65 @@ public class SilksongVersionInfo : Enumeration
     public static readonly SilksongVersionInfo _1_0_28714 = new()
     {
         Value = "1.0.28714",
-        WindowsManifestId = "5977483240701257214",
-        MacManifestId = "7917356342743942630",
-        LinuxManifestId = "1617544312110692774"
+        WindowsManifestId = 5977483240701257214,
+        MacManifestId = 7917356342743942630,
+        LinuxManifestId = 1617544312110692774
     };
 
     public static readonly SilksongVersionInfo _1_0_28891 = new()
     {
         Value = "1.0.28891",
-        WindowsManifestId = "3690203822520536668",
-        MacManifestId = "2374057204384257562",
-        LinuxManifestId = "5954103139200615141"
+        WindowsManifestId = 3690203822520536668,
+        MacManifestId = 2374057204384257562,
+        LinuxManifestId = 5954103139200615141
     };
 
     public static readonly SilksongVersionInfo _1_0_29242 = new()
     {
         Value = "1.0.29242",
-        WindowsManifestId = "426651197780377263",
-        MacManifestId = "2058007571598677908",
-        LinuxManifestId = "8078874762924599313"
+        WindowsManifestId = 426651197780377263,
+        MacManifestId = 2058007571598677908,
+        LinuxManifestId = 8078874762924599313
     };
 
     public static readonly SilksongVersionInfo _1_0_29315 = new()
     {
         Value = "1.0.29315",
-        WindowsManifestId = "3545882420322545098",
-        MacManifestId = "7345001466169537628",
-        LinuxManifestId = "4349246050376532986"
+        WindowsManifestId = 3545882420322545098,
+        MacManifestId = 7345001466169537628,
+        LinuxManifestId = 4349246050376532986
     };
 
     public static readonly SilksongVersionInfo _1_0_29909 = new()
     {
         Value = "1.0.29909",
-        WindowsManifestId = "3853982342899707391",
-        MacManifestId = "8626896570586771768",
-        LinuxManifestId = "2218100490558811317"
+        WindowsManifestId = 3853982342899707391,
+        MacManifestId = 8626896570586771768,
+        LinuxManifestId = 2218100490558811317
     };
 
     public static readonly SilksongVersionInfo _1_0_29926 = new()
     {
         Value = "1.0.29926",
-        WindowsManifestId = "3703686001292550981",
-        MacManifestId = "4837712425280970616",
-        LinuxManifestId = "6891565886978421564"
+        WindowsManifestId = 3703686001292550981,
+        MacManifestId = 4837712425280970616,
+        LinuxManifestId = 6891565886978421564
     };
 
     public static readonly SilksongVersionInfo _1_0_29980 = new()
     {
         Value = "1.0.29980",
-        WindowsManifestId = "468692862190470536",
-        MacManifestId = "4899622998101152532",
-        LinuxManifestId = "7780372375671997910"
+        WindowsManifestId = 468692862190470536,
+        MacManifestId = 4899622998101152532,
+        LinuxManifestId = 7780372375671997910
     };
 
     public static readonly SilksongVersionInfo _1_0_30000 = new()
     {
         Value = "1.0.30000",
-        WindowsManifestId = "4421626056705534276",
-        MacManifestId = "4136280015582261500",
-        LinuxManifestId = "7921642076658611197"
+        WindowsManifestId = 4421626056705534276,
+        MacManifestId = 4136280015582261500,
+        LinuxManifestId = 7921642076658611197
     };
 
     public class Converter : TypeConverter

--- a/build/SteamClientWrapper.cs
+++ b/build/SteamClientWrapper.cs
@@ -1,0 +1,245 @@
+﻿using QRCoder;
+using Serilog;
+using SteamKit2;
+using SteamKit2.Authentication;
+using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CDN = SteamKit2.CDN;
+
+namespace _build;
+
+
+[Serializable]
+public class SteamClientException : Exception
+{
+    public SteamClientException() { }
+    public SteamClientException(string message) : base(message) { }
+    public SteamClientException(string message, Exception inner) : base(message, inner) { }
+}
+
+internal class SteamClientWrapper
+{
+    public const uint APP_ID = SilksongVersionInfo.STEAM_APPID;
+
+    public record CdnAuthInfo(byte[] DepotKey, string CdnAuthToken);
+
+    private SteamClient Client { get; }
+    private SteamUser User { get; }
+    private SteamApps Apps { get; }
+    private SteamContent Content { get; }
+
+    private CDN.Client CdnClient { get; }
+    private CDN.Server CdnProxyServer { get; set; }
+    private CDN.Server CdnServer { get; set; }
+    private readonly SemaphoreSlim cdnSemaphore = new(1, 1);
+
+    // key is depot id. values are lazy tasks because getoradd may run the code twice and cannot handle async code.
+    // use GetAuthForDepotAsync. See https://andrewlock.net/making-getoradd-on-concurrentdictionary-thread-safe-using-lazy/
+    private readonly ConcurrentDictionary<uint, Lazy<Task<CdnAuthInfo>>> loginInfos = [];
+
+    public SteamClientWrapper()
+    {
+        Client = new();
+        User = Client.GetHandler<SteamUser>();
+        Apps = Client.GetHandler<SteamApps>();
+        Content = Client.GetHandler<SteamContent>();
+
+        CdnClient = new(Client);
+    }
+
+    /// <summary>
+    /// Asynchronously establishes a connection to the server and attempts to log in using the specified credentials.
+    /// If either the username or password is null, Steam Guard QR login will be used instead.
+    /// </summary>
+    /// <remarks>If the connection or authentication fails, the returned task will complete with an exception.</remarks>
+    /// <param name="username">The optional user name to use for authentication.</param>
+    /// <param name="password">The optional password associated with the specified user name.</param>
+    /// <returns>A task that represents the asynchronous connect and login operation.</returns>
+    public Task ConnectAndLoginAsync(string username, string password)
+    {
+        return Task.Run(() => ConnectAndLoginInternal(username, password));
+    }
+
+    public Task LogOutAsync()
+    {
+        return Task.Run(User.LogOff);
+    }
+
+    public async Task<DepotManifest> GetManifestAsync(uint depotId, ulong manifestId)
+    {
+        CdnAuthInfo authInfo = await GetAuthForDepotAsync(depotId);
+        ulong manifestRequestCode = await Content.GetManifestRequestCode(depotId, APP_ID, manifestId);
+        return await CdnClient.DownloadManifestAsync(
+            depotId,
+            manifestId,
+            manifestRequestCode,
+            CdnServer,
+            authInfo.DepotKey,
+            CdnProxyServer,
+            authInfo.CdnAuthToken
+        );
+    }
+
+    public async Task DownloadFileAsync(uint depotId, DepotManifest.FileData file, FileInfo destination, CancellationToken ct = default)
+    {
+        CdnAuthInfo authInfo = await GetAuthForDepotAsync(depotId);
+        using FileStream fs = destination.OpenWrite();
+        fs.SetLength((long)file.TotalSize);
+        foreach (DepotManifest.ChunkData chunk in file.Chunks)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            byte[] chunkBytesUncompressed = ArrayPool<byte>.Shared.Rent((int)chunk.UncompressedLength);
+            int written = await CdnClient.DownloadDepotChunkAsync(
+                depotId,
+                chunk,
+                CdnServer,
+                chunkBytesUncompressed,
+                authInfo.DepotKey,
+                CdnServer,
+                authInfo.CdnAuthToken
+            );
+            if (written == 0)
+            {
+                throw new SteamClientException($"Unable to retrieve chunk {Convert.ToHexString(chunk.ChunkID)}");
+            }
+            fs.Seek((long)chunk.Offset, SeekOrigin.Begin);
+            await fs.WriteAsync(chunkBytesUncompressed.AsMemory(0, written), ct);
+            ArrayPool<byte>.Shared.Return(chunkBytesUncompressed);
+        }
+    }
+
+    private void ConnectAndLoginInternal(string username, string password)
+    {
+        CallbackManager manager = new(Client);
+
+        bool continueEventLoop = true;
+
+        manager.Subscribe<SteamClient.ConnectedCallback>(async args =>
+        {
+            Log.Information("Logging in to steam...");
+            AuthPollResult pollResponse;
+            if (username != null && password != null)
+            {
+                pollResponse = await AuthenticateWithCredentialsAsync(username, password);
+            }
+            else
+            {
+                pollResponse = await AuthenticateWithQrAsync();
+            }
+
+            Log.Information("Logging in as {User}", pollResponse.AccountName);
+            User.LogOn(new SteamUser.LogOnDetails
+            {
+                Username = pollResponse.AccountName,
+                AccessToken = pollResponse.RefreshToken,
+                LoginID = 0x4E554B45 // The ascii characters of "NUKE" in hex, to ensure uniqueness against default logged in steam client sessions
+            });
+        });
+        manager.Subscribe<SteamClient.DisconnectedCallback>(args =>
+        {
+            throw new SteamClientException("Lost connection to the server");
+        });
+
+        manager.Subscribe<SteamUser.LoggedOnCallback>(args =>
+        {
+            if (args.Result != EResult.OK)
+            {
+                throw new SteamClientException($"Unable to log in to Steam: {args.Result} / {args.ExtendedResult}");
+            }
+            Log.Information("Successfully logged in!");
+            continueEventLoop = false;
+        });
+
+        Client.Connect();
+        while (continueEventLoop)
+        {
+            manager.RunWaitCallbacks(TimeSpan.FromSeconds(1));
+        }
+    }
+
+    private async Task<AuthPollResult> AuthenticateWithCredentialsAsync(string user, string password)
+    {
+        CredentialsAuthSession session = await Client.Authentication.BeginAuthSessionViaCredentialsAsync(new AuthSessionDetails
+        {
+            Username = user,
+            Password = password,
+            Authenticator = new UserConsoleAuthenticator()
+        });
+
+        return await session.PollingWaitForResultAsync();
+    }
+
+    private async Task<AuthPollResult> AuthenticateWithQrAsync()
+    {
+        QrAuthSession session = await Client.Authentication.BeginAuthSessionViaQRAsync(new AuthSessionDetails());
+        session.ChallengeURLChanged = () =>
+        {
+            Log.Information("Steam has refreshed the challenge URL");
+            DrawQRCode(session);
+        };
+        DrawQRCode(session);
+
+        return await session.PollingWaitForResultAsync();
+    }
+
+    private void DrawQRCode(QrAuthSession authSession)
+    {
+        Log.Information("Challenge URL: {Challenge}", authSession.ChallengeURL);
+
+        // Encode the link as a QR code
+        using QRCodeGenerator qrGenerator = new QRCodeGenerator();
+        QRCodeData qrCodeData = qrGenerator.CreateQrCode(authSession.ChallengeURL, QRCodeGenerator.ECCLevel.L);
+        using AsciiQRCode qrCode = new AsciiQRCode(qrCodeData);
+        string qrCodeAsAsciiArt = qrCode.GetGraphic(1, drawQuietZones: false);
+
+        Log.Information("Use the Steam Mobile App to sign in via QR code");
+        // intentionally doesn't use serilog; don't want to populate it to disk plus formatting is wonky
+        Console.WriteLine(qrCodeAsAsciiArt);
+    }
+
+    private async Task EnsureCdnAsync()
+    {
+        // do the cheap check to see if we need to bother claiming the lock at all
+        if (CdnServer == null)
+        {
+            await cdnSemaphore.WaitAsync();
+            try
+            {
+                // check again to make sure we didn't get race conditioned between the first check and claiming the lock
+                if (CdnServer == null)
+                {
+                    IReadOnlyCollection<CDN.Server> servers = await Content.GetServersForSteamPipe();
+                    CdnProxyServer = servers.Where(s => s.UseAsProxy).FirstOrDefault();
+                    CdnServer = servers.Where(s =>
+                    {
+                        bool isEligible = s.AllowedAppIds.Length == 0 || s.AllowedAppIds.Contains(APP_ID);
+                        return isEligible && (s.Type == "SteamCache" || s.Type == "CDN");
+                    }).OrderBy(s => s.WeightedLoad).First();
+                }
+            }
+            finally
+            {
+                cdnSemaphore.Release();
+            }
+        }
+    }
+
+    private async Task<CdnAuthInfo> GetAuthForDepotAsync(uint depotId)
+    {
+        await EnsureCdnAsync();
+        Lazy<Task<CdnAuthInfo>> lazyTask = loginInfos.GetOrAdd(depotId, new Lazy<Task<CdnAuthInfo>>(async () =>
+        {
+            SteamApps.DepotKeyCallback depotKeyResult = await Apps.GetDepotDecryptionKey(depotId, APP_ID);
+            SteamContent.CDNAuthToken cdnAuthToken = await Content.GetCDNAuthToken(APP_ID, depotId, CdnServer.Host);
+            return new CdnAuthInfo(depotKeyResult.DepotKey, cdnAuthToken.Token);
+        }));
+        return await lazyTask.Value;
+    }
+}

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -13,6 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="10.1.0" />
+    <PackageReference Include="SteamKit2" Version="3.4.0" />
+    <PackageReference Include="QRCoder" Version="1.7.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Summary of Changes

This change enables automatically downloading historic patches via [SteamKit2](https://github.com/SteamRE/SteamKit). This removes the need for manual file system operations and setting up/learning external tools like DepotDownloader. It also makes it significantly less painful for people other than me (who has been keeping a manual local record of all the game files for each version since launch; also very painful btw) to set up this package. It also brings us several steps closer to CI - if we could be automatically notified of updates we could basically fully automate this package end-to-end, though I would ideally want to make a sacrificial steam account for the bot to use so we can turn off steam guard and not worry about what happens if credentials leak

### Checklist

* No change is too small for a release, so pick one:
  * [x] This PR does not update user-facing code/config

### Testing

I tested this fairly extensively, including verifying that the downloaded files for current patch (1.0.30000) are byte-for-byte identical to my managed folder. However I'd love for other people (esp org people) to test it as well and make sure CDN stuff works right in different parts of the world
  
